### PR TITLE
CMakeLists.txt: integrate googletest as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "abseil"]
 	path = abseil
 	url = https://github.com/abseil/abseil-cpp.git
+[submodule "googletest"]
+	path = googletest
+	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ find_package(
   REQUIRED
   COMPONENTS context)
 
-include CTest
+include(CTest)
 if(BUILD_TESTING)
   include(GoogleTest)
   add_subdirectory(googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ find_package(
 option(MAKO_BUILD_TESTING
     "If ON, Mako will build all of Mako's own tests." OFF)
 
-if(${MAKO_BUILD_TESTING})
-  include(CTest)
+include CTest
+if(BUILD_TESTING)
   include(GoogleTest)
   add_subdirectory(googletest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,13 +41,19 @@ string(APPEND CMAKE_CUDA_FLAGS " ${TORCH_CUDA_FLAGS}")
 set(ABSL_PROPAGATE_CXX_STD ON)
 add_subdirectory(abseil)
 
-add_subdirectory(googletest)
-enable_testing()
-
 find_package(
   Boost
   1.74.0
   REQUIRED
   COMPONENTS context)
+
+option(MAKO_BUILD_TESTING
+    "If ON, Mako will build all of Mako's own tests." OFF)
+
+if(${MAKO_BUILD_TESTING})
+  include(CTest)
+  include(GoogleTest)
+  add_subdirectory(googletest)
+endif()
 
 add_subdirectory(mako)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,6 @@ find_package(
   REQUIRED
   COMPONENTS context)
 
-option(MAKO_BUILD_TESTING
-    "If ON, Mako will build all of Mako's own tests." OFF)
-
 include CTest
 if(BUILD_TESTING)
   include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ string(APPEND CMAKE_CUDA_FLAGS " ${TORCH_CUDA_FLAGS}")
 set(ABSL_PROPAGATE_CXX_STD ON)
 add_subdirectory(abseil)
 
+add_subdirectory(googletest)
+enable_testing()
+
 find_package(
   Boost
   1.74.0

--- a/mako/CMakeLists.txt
+++ b/mako/CMakeLists.txt
@@ -28,5 +28,4 @@ target_link_libraries(
   absl::strings
   ${Boost_CONTEXT_LIBRARY}
   mako::nn
-  mako::utils
-  gtest)
+  mako::utils)

--- a/mako/CMakeLists.txt
+++ b/mako/CMakeLists.txt
@@ -28,4 +28,5 @@ target_link_libraries(
   absl::strings
   ${Boost_CONTEXT_LIBRARY}
   mako::nn
-  mako::utils)
+  mako::utils
+  gtest)


### PR DESCRIPTION
This PR integrates googletest to the project, by adding googletest project as submodule